### PR TITLE
아카이브 메뉴 - '휴지통으로' 기능 추가 #81

### DIFF
--- a/frontend/src/components/archive-util/ArchiveContextMenu.js
+++ b/frontend/src/components/archive-util/ArchiveContextMenu.js
@@ -9,6 +9,7 @@ import CreateBookmarkModal from "./CreateBookmarkModal";
 import ArchiveUpdateLocationModal from "./ArchiveUpdateLocationModal";
 import {useGlobalScroll} from "../../layout/GlobalScrollLayout";
 import {useArchiveSectionRefresh} from "../archive/ArchiveSection";
+import {useLogin} from "../../hooks/useLogin";
 
 const isValidName = (name) => {
     const expression = /^[a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ_\- !()]{1,50}$/;
@@ -32,6 +33,7 @@ const useModal = () => {
 }
 
 const ArchiveContextMenu = ({children, isActive, onIsRendered, archive, onIsActiveDrag, onRename}) => {
+    const {accessToken} = useLogin();
     const [isClickedRenameModal, openRenameModal, closeRenameModal] = useModal();
     const [isClickedCreateFolderModal, openCreateFolderModal, closeCreateFolderModal] = useModal();
     const [isClickedCreateBookmarkModal, openCreateBookmarkModal, closeCreateBookmarkModal] = useModal();
@@ -86,6 +88,22 @@ const ArchiveContextMenu = ({children, isActive, onIsRendered, archive, onIsActi
         }
     }
 
+    const deleteArchive = () => {
+        fetch(process.env.REACT_APP_SERVER + "/storage/" + archiveType + "/" + archive.id, {
+            method: "DELETE",
+            headers: {
+                "Content-Type": "application/problem+json",
+                "Accept": "application/problem+json",
+                "Authorization": `Bearer ${accessToken}`
+            }
+        })
+            .then(res => res.json())
+            .then(data => {
+                refresh();
+            })
+            .catch(err => console.error("Error fetching delete archive:", err));
+    }
+
     return (
         <>
             <StyledArchiveContextMenuTrigger onContextMenu={handleMenuOpen}>
@@ -122,8 +140,10 @@ const ArchiveContextMenu = ({children, isActive, onIsRendered, archive, onIsActi
                     }}>
                         위치 변경
                     </StyledArchiveMenuItem>
-                    <StyledArchiveMenuItem onClick={closeMenu}>
-                        닫기
+                    <StyledArchiveMenuItem onClick={() => {
+                        deleteArchive();
+                    }}>
+                        휴지통으로
                     </StyledArchiveMenuItem>
                 </StyledArchiveContextMenu>
             }


### PR DESCRIPTION
## 구현

아카이브 컨텍스트 메뉴에 휴지통으로 이동하는 기능 추가

아카이브 모달은 다른 곳을 클릭하면 사라지기 때문에 필수적인 요소가 아니므로 메뉴의 개수를 줄이고자 기존의 '닫기' 메뉴는 삭제함

